### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "dependencies": {
     "jile": "^2.0.2",
     "lodash": "^4.17.2",
-    "node-uuid": "^1.4.7",
-    "react": "^15.4.0"
+    "react": "^15.4.0",
+    "uuid": "^3.0.0"
   },
   "description": "Decorator for jile usage on React components",
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 // external dependencies
 import isFunction from 'lodash/isFunction';
 import isPlainObject from 'lodash/isPlainObject';
-import uuid from 'node-uuid';
+import uuid from 'uuid';
 import React, {
   Component
 } from 'react';

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,7 +2,7 @@
 import find from 'lodash/find';
 import isPlainObject from 'lodash/isPlainObject';
 import jile from 'jile';
-import uuid from 'node-uuid';
+import uuid from 'uuid';
 
 let cache = {};
 


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.